### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
     <licenses>
         <license>
             <name>Apache Software License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
 
     <issueManagement>
         <system>jira</system>
-        <url>http://jira.springframework.org/browse/SESPRINGACTIONSCRIPTAS</url>
+        <url>https://jira.springframework.org/browse/SESPRINGACTIONSCRIPTAS</url>
     </issueManagement>
 
     <mailingLists>
@@ -74,7 +74,7 @@
             <subscribe>springactionscript-dev+subscribe@googlegroups.com</subscribe>
             <unsubscribe>springactionscript-dev+unsubscribe@googlegroups.com</unsubscribe>
             <post>springactionscript-dev@googlegroups.com</post>
-            <archive>http://groups.google.com/group/springactionscript-dev</archive>
+            <archive>https://groups.google.com/group/springactionscript-dev</archive>
         </mailingList>
     </mailingLists>
 
@@ -83,7 +83,7 @@
             <id>cherreman</id>
             <name>Christophe Herreman</name>
             <email>christophe.herreman [at] stackandheap.com</email>
-            <url>http://www.herrodius.com</url>
+            <url>https://www.herrodius.com</url>
             <organization>Stack &amp; Heap</organization>
             <organizationUrl>http://www.stackandheap.com</organizationUrl>
             <timezone>+1</timezone>
@@ -92,7 +92,7 @@
             <id>rzwaga</id>
             <name>Roland Zwaga</name>
             <email>roland.zwaga [at] stackandheap.com</email>
-            <url>http://zwaga.blogspot.com/</url>
+            <url>https://zwaga.blogspot.com/</url>
             <organization>Stack &amp; Heap</organization>
             <organizationUrl>http://www.stackandheap.com</organizationUrl>
             <timezone>+1</timezone>
@@ -342,7 +342,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <!--
                         Must not be 2.2-beta-1 which is distributed with Maven 2.2.0 because of
-                        http://jira.codehaus.org/browse/MASSEMBLY-285
+                        https://jira.codehaus.org/browse/MASSEMBLY-285
                         -->
                 <version>2.2-beta-4</version>
                 <inherited>false</inherited>
@@ -830,7 +830,7 @@
         </repository>
         <repository>
             <id>flex-mojos-repository</id>
-            <url>http://repository.sonatype.org/content/groups/public</url>
+            <url>https://repository.sonatype.org/content/groups/public</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -840,7 +840,7 @@
         </repository>
         <repository>
             <id>flex-mojos-flex-repository</id>
-            <url>http://repository.sonatype.org/content/groups/flexgroup</url>
+            <url>https://repository.sonatype.org/content/groups/flexgroup</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -850,14 +850,14 @@
         </repository>
         <repository>
             <id>yoolab.org-releases</id>
-            <url>http://projects.yoolab.org/maven/content/repositories/releases</url>
+            <url>https://projects.yoolab.org/maven/content/repositories/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
         </repository>
         <repository>
             <id>yoolab.org-snapshots</id>
-            <url>http://projects.yoolab.org/maven/content/repositories/snapshots</url>
+            <url>https://projects.yoolab.org/maven/content/repositories/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -867,7 +867,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>flexmojos-plugin</id>
-            <url>http://repository.sonatype.org/content/groups/flexgroup</url>
+            <url>https://repository.sonatype.org/content/groups/flexgroup</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.springactionscript.org (200) could not be migrated:  
   ([https](https://www.springactionscript.org) result SSLHandshakeException).
* http://opensource.adobe.com/svn/opensource/cairngorm3/maven-repository (404) could not be migrated:  
   ([https](https://opensource.adobe.com/svn/opensource/cairngorm3/maven-repository) result SSLHandshakeException).
* http://www.springactionscript.org/mxml/config (404) could not be migrated:  
   ([https](https://www.springactionscript.org/mxml/config) result SSLHandshakeException).
* http://www.stackandheap.com (500) could not be migrated:  
   ([https](https://www.stackandheap.com) result SSLHandshakeException).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance